### PR TITLE
Fixed canvas issues with resizing the browser window & drawing line behind image.

### DIFF
--- a/js/CanvasController.js
+++ b/js/CanvasController.js
@@ -1,7 +1,11 @@
 function initCanvas(canvas, ctx) {
-    canvas.addEventListener("resize", setCanvasDimensions, false);
-    canvas.addEventListener("mousemove", function (e) {update(e, ctx);}, false);
-    setCanvasDimensions(canvas)
+    window.addEventListener("resize", setCanvasDimensions, false);
+    document.addEventListener("mousemove", function (e) {
+                                            var mouseX = e.x * canvas.width / canvas.clientWidth | 0;
+                                            var mouseY = e.y * canvas.height / canvas.clientHeight | 0;
+                                            update(mouseX, mouseY, canvas, ctx);
+                                            }, false);
+    setCanvasDimensions(canvas);
 }
 
 function setCanvasDimensions(canvas) {
@@ -9,20 +13,20 @@ function setCanvasDimensions(canvas) {
     canvas.width = window.innerWidth;
 }
 
-function calculateLineEndpointX(mouseX){
-    if (mouseX > window.innerWidth/2) {
-        return window.innerWidth + 100;
+function calculateLineEndpointX(mouseX, canvas){
+    if (mouseX > canvas.width/2) {
+        return canvas.width + 100;
     }
     return -100;
 }
 
-function update(e, ctx) {
-    ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+function update(x, y, canvas, ctx) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.beginPath();
-    ctx.moveTo(calculateLineEndpointX(e.x), e.y);
-    ctx.lineTo(e.x, e.y);
+    ctx.moveTo(calculateLineEndpointX(x, canvas), y);
+    ctx.lineTo(x, y);
     ctx.lineWidth = 100;
     ctx.lineCap = 'round';
-    ctx.strokeStyle ='#0a0a0a';
+    ctx.strokeStyle = '#0a0a0a';
     ctx.stroke();
 }


### PR DESCRIPTION
Previously, drawings made to the canvas after the browser window was resized would be stretched or squashed. As well, the line would not follow the mouse cursor behind the image of the snake.

These fixes happened because of @redsummernight, who spotted a number of bugs that I didn't notice. Thank you!